### PR TITLE
fix(chart-releaser): add repo dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,15 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - name: Add dependency chart repos
+        run: |
+          helm repo add stable https://charts.helm.sh/stable
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0-rc.1

--- a/charts/caluma/Chart.yaml
+++ b/charts/caluma/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: caluma
 description: A collaborative form editing service
-version: 0.10.0
+version: 0.10.1
 appVersion: 6.6.0
 keywords:
 - caluma

--- a/charts/caluma/requirements.lock
+++ b/charts/caluma/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.5.1
+  repository: https://charts.helm.sh/stable
+  version: 6.5.9
 - name: minio
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 2.5.16
-digest: sha256:cdbcc3addb68bb7b2acae0bdc8b9e520cfc5566eba51492c9012567b6a0b0b6b
-generated: "2019-10-24T16:03:06.730451954+02:00"
+  repository: https://charts.helm.sh/stable
+  version: 2.5.18
+digest: sha256:d545e68a31122cbd89b0596918ec8a9d600711070a28c2f404196235e9ca7e6d
+generated: "2021-01-06T11:43:05.244128796+01:00"

--- a/charts/caluma/requirements.yaml
+++ b/charts/caluma/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   version: 6.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable
   condition: postgresql.enabled
 - name: minio
   version: 2.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable
   condition: minio.enabled

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,3 +1,3 @@
 chart-repos:
-  - stable=https://kubernetes-charts.storage.googleapis.com/
+  - stable=https://charts.helm.sh/stable
 helm-extra-args: --timeout 600s


### PR DESCRIPTION
Adds the repo dependencies in the chart-releaser CI and fixes the OLD DEPRECATED `kubernetes-charts.googleapis.com` with the archived version of `charts.helm.sh`