### PR TITLE
add postgresql.existingHost & existingSecret for backend's SECRETKEY

### DIFF
--- a/charts/caluma/Chart.yaml
+++ b/charts/caluma/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.8
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/caluma/templates/backend-deployment.yaml
+++ b/charts/caluma/templates/backend-deployment.yaml
@@ -27,7 +27,16 @@ spec:
           imagePullPolicy: {{ .Values.image.backend.pullPolicy }}
           env:
             - name: DATABASE_HOST
+              {{- if and .Values.postgresql.enabled .Values.backend.postgresql.existingHost }}
+              {{ fail "postgresql.enabled and backend.postgresql.existingHost are mutually exclusive, please pick one" }}
+              {{- end }}
+              {{- if .Values.postgresql.enabled }}
               value: "{{ template "caluma.fullname" . }}-postgresql"
+              {{- else if .Values.backend.postgresql.existingHost }}
+              value: {{ .Values.backend.postgresql.existingHost | quote }}
+              {{- else }}
+              {{ fail "neither postgresql.enabled or backend.postgresql.existingHost are set, please pick one" }}
+              {{- end }}
             - name: DATABASE_PORT
               value: "5432"
             - name: DATABASE_USER
@@ -40,7 +49,11 @@ spec:
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.existingSecret }}
+                  name: {{ .Values.existingSecret | quote }}
+                  {{- else }}
                   name: "{{ template "caluma.fullname" . }}-backend"
+                  {{- end }}
                   key: secretkey
             - name: ALLOWED_HOSTS
               value: "{{ .Values.allowedHosts }}"

--- a/charts/caluma/templates/backend-secret.yaml
+++ b/charts/caluma/templates/backend-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret }}
 {{- $fullName := include "caluma.fullname" . -}}
 apiVersion: v1
 kind: Secret
@@ -9,3 +10,4 @@ metadata:
 type: Opaque
 data:
   secretkey: {{ if .Values.secretKey }}{{ .Values.secretKey | b64enc | quote }}{{ else }}{{ randAlphaNum 40 | b64enc | quote }}{{ end }}
+{{- end }}

--- a/charts/caluma/values.yaml
+++ b/charts/caluma/values.yaml
@@ -32,6 +32,11 @@ nameOverride: ""
 fullnameOverride: ""
 
 secretKey: "SUPERSECRET"
+# instead of exposing the secretKey in the values, a existingSecret can be defined 
+# if set no secret will be created by the Helm chart.
+# create the secret manually:
+# kubectl create secret generic -n your-namespace --from-literal=secretKey=SUPERSECRETKEY
+existingSecret: ""
 allowedHosts: "*"
 
 frontend:
@@ -53,6 +58,12 @@ backend:
   #   value: example
   service:
     type: ClusterIP
+
+  postgresql:
+    ## Optionally sepcify an existing database host to connect to
+    ## this can only be used if postgresql.enabled is set to false
+    existingHost: ""
+
 
 ingress:
   enabled: false

--- a/charts/caluma/values.yaml
+++ b/charts/caluma/values.yaml
@@ -32,7 +32,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 secretKey: "SUPERSECRET"
-# instead of exposing the secretKey in the values, a existingSecret can be defined 
+# instead of exposing the secretKey in the values, a existingSecret can be defined
 # if set no secret will be created by the Helm chart.
 # create the secret manually:
 # kubectl create secret generic -n your-namespace --from-literal=secretKey=SUPERSECRETKEY


### PR DESCRIPTION
 add an existingSecret for the SECREKEY and allow setting an existingHost for the database

This change will make it possible to deploy caluma on Production (There we have DBaaS)

What I also saw and needs fixing is the initDBScripts which are potentially not run anymore due to the update to the newest postgresql Version. I'll create an issue for it. 